### PR TITLE
Fix acceptance of '000' sequence in Personnummer num part

### DIFF
--- a/lib/personnummer.rb
+++ b/lib/personnummer.rb
@@ -70,7 +70,7 @@ module Personnummer
     # Raises error if regex is refused.
     # (Hash)
     def get_parts(personnummer)
-      reg = /^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$/;
+      reg = /(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\+\-\s]?)((?!000)\d{3})(\d)/;
       match = personnummer.to_s.match(reg)
 
       if !match

--- a/test/test_personnummer.rb
+++ b/test/test_personnummer.rb
@@ -33,6 +33,7 @@ class PersonnummerTest < Minitest::Test
         assert_equal false, Personnummer::valid?('990919+3776')
         assert_equal false, Personnummer::valid?('990919-3776')
         assert_equal false, Personnummer::valid?('9909193776')
+        assert_equal false, Personnummer::valid?('20150916-0006')
     end
 
     def test_coordination_numbers


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [x] Security patch
- [ ] Documentation update

**Description**

This PR modifies the regex check to disallow the `000` sequence from the num part, as it should only be accepting numbers in the range `001-999`. It also adds a test coverage for such an example.

**Related issue**

<!-- Issue which this PR is connected to, if any. -->
This issue will resolve #9 when merged.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [ ] Tests passes.
- [ ] Style lints passes.
- [x] Documentation of new public methods exists.
- [x] New tests added which covers the added code.
