### PR TITLE
CI: Drop unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ rvm:
   - 2.5
   - 2.6
   - jruby-9.2.7.0
-sudo: false


### PR DESCRIPTION
**Type of change**

CI config cleanup.

**Description**

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

**Motivation**

A shorter easier to read CI config is... easier.

