### PR TITLE
CI: Include non-EOL Ruby versions in build matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7]
+        ruby-version: [3.1, 3.2, 3.3, 3.4]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
**Type of change**

CI maintenance. This builds green today.

**Description**

This PR uses the current versions of Ruby in the CI build matrix. [More about the dates of EOL.](https://endoflife.date/ruby)

All other versions have been removed.

**Motivation**

We'd like to ensure personnummer/ruby's longevity & compatibility with current Ruby versions.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests pass.
- [ ] Style lints pass. (Noting in passing: There are no such rules or tools in this repository.)